### PR TITLE
feat: suite function for v0.1.2

### DIFF
--- a/bin/test.ts
+++ b/bin/test.ts
@@ -2,6 +2,7 @@
 import { SpawnOptions } from "child_process";
 import { joinPathSep } from "./helper.js";
 import { spawn } from "child_process";
+import chalk from "chalk";
 
 export const run = () => {
     // correcting the separator for the path given by the users
@@ -20,7 +21,7 @@ export const run = () => {
     const childProcess = spawn(command, args, options);
 
     childProcess.stdout?.on("data", (data) => {
-        console.log(data.toString());
+        console.log(chalk(data.toString()));
     });
 
     childProcess.on('error', (err) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "polaris-suite",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "polaris-suite",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "ISC",
       "dependencies": {
         "chalk": "^5.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "polaris-suite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "polaris-suite",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
         "chalk": "^5.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "polaris-suite",
-  "version": "1.0.7",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "polaris-suite",
-      "version": "1.0.7",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "chalk": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "easy to use, lite weight and collaborative automated testing suite for web applications",
   "main": "index.js",
   "type": "module",
-  "types": "build/src/index.d.ts",
+  "types": "types/index.d.ts",
   "files": [
     "build/src",
     "build/bin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polaris-suite",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "easy to use, lite weight and collaborative automated testing suite for web applications",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "polaris-suite",
-  "version": "1.0.7",
+  "version": "0.0.7",
   "description": "easy to use, lite weight and collaborative automated testing suite for web applications",
   "main": "index.js",
   "type": "module",
-  "types": "types/index.d.ts",
+  "types": "build/src/index.d.ts",
   "files": [
     "build/src",
     "build/bin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polaris-suite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "easy to use, lite weight and collaborative automated testing suite for web applications",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polaris-suite",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "easy to use, lite weight and collaborative automated testing suite for web applications",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./build/src/index.js",
-      "require": "./index.js"
-    }
+      "default": "./build/src/index.js",
+      "types": "./build/src/index.d.ts"
+    },
+    "./package.json": "./package.json",
+    "./bin": "./build/bin/test.js"
   },
   "scripts": {
     "test": "tsc && node build/__tests__/index.js",

--- a/src/global_functions/index.ts
+++ b/src/global_functions/index.ts
@@ -5,6 +5,9 @@ let numberOfTests: number = 0;
 // total number of failed tests (global variable)
 let numberOfFailedTests: number = 0;
 
+let numberOfSuites: number = 0;
+let numberOfFailedSuites: number = 0;
+
 /**
  * 
  * @param name name of the test
@@ -26,4 +29,34 @@ export const test = (name: string, fn: Function) => {
         console.log('\n');
         console.log(error);
     }
+}
+
+/**
+ * 
+ * @param name name of the suite
+ * @param fn function that contains the test functions
+ */
+export const suite = (name: string, fn: Function) => {
+    // storing the previous number of failed tests
+    const numberOfFailedTestsTillNow = numberOfFailedTests;
+
+    // incrementing number of test suites
+    numberOfSuites++;
+
+    // executing the function
+    fn();
+
+    // incrementing number of failed test suites if the number of previous failed test is less than new number of failed test
+    if(numberOfFailedTestsTillNow < numberOfFailedTests) {
+        numberOfFailedSuites++;
+    }
+}
+
+/**
+ * logs the result summary after running the tests
+ */
+export const result = () => {
+    console.log("\n");
+    console.log(formattedText(`Test Suites: ${numberOfFailedSuites > 0 ? coloredText(`${numberOfFailedSuites} failed`).error() + "," : ""} ${coloredText(`${numberOfSuites-numberOfFailedSuites} passed`).success()}, ${numberOfSuites} total`).bold());
+    console.log(formattedText(`Test Cases: ${numberOfFailedTests > 0 ? coloredText(`${numberOfFailedTests} failed`).error()+',' : ""} ${coloredText(`${numberOfTests-numberOfFailedTests} passed`).success()}, ${numberOfTests} total`).bold());
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { expect } from './packages/expect/index.js';
 export { call } from './packages/call/index.js';
 export { component } from './packages/component/index.js';
-export { test } from './global_functions/index.js';
+export { test, suite, result } from './global_functions/index.js';

--- a/src/packages/call/index.ts
+++ b/src/packages/call/index.ts
@@ -27,19 +27,15 @@ export const call = (fn: Function, params?: Array<any>): CallResult => {
         returns: (result: any) => {
             const res = fn(...params!);
 
-            if(checkEqual(res, result)) console.log('Test passed');
-            else {
+            if(!checkEqual(res, result)) 
                 throw new CustomError(bgColor('Test Failed').error(), `${expectMessage(res.toString(), result)}`);
-            }
         },
         not: {
             returns: (result: any) => {
                 const res = fn(...params!);
 
-                if(!checkEqual(res, result)) console.log('Test passed');
-                else {
+                if(checkEqual(res, result)) 
                     throw new CustomError(bgColor('Test Failed').error(), `${expectMessage(`not to be ${res.toString()}`, result)}`);
-                }
             }
         }
     }

--- a/src/packages/expect/index.ts
+++ b/src/packages/expect/index.ts
@@ -10,37 +10,27 @@ import { CustomError, expectMessage } from "../../helpers/error/index.js";
 export const expect = (actual: any): ExpectationResult => {
     let expectation = {
         equalsTo: (expected: any) => {
-            if(checkEqual(actual, expected)){
-                console.log(bgColor('Test Passed').success());
-            }else {
+            if(!checkEqual(actual, expected)){
                 throw new CustomError(bgColor('Test Failed').error(), `${expectMessage(expected.toString(), actual)}`);
             }
         },
         toBeNull: () => {
-            if(actual === null){
-                console.log(bgColor('Test Passed').success());
-            }else {
+            if(actual !== null){
                 throw new CustomError(bgColor('Test Failed').error(), `${expectMessage('null', typeof actual)}`);
             }
         },
         toBeString: () => {
-            if(typeof actual === 'string'){
-                console.log('Test Passed');
-            }else {
+            if(typeof actual !== 'string'){
                 throw new CustomError(bgColor('Test Failed').error(), `${expectMessage('string', typeof actual)}`);
             }
         },
         toBeNumber: () => {
-            if(typeof actual === 'number'){
-                console.log('Test Passed');
-            }else {
+            if(typeof actual !== 'number'){
                 throw new CustomError(bgColor('Test Failed').error(), `${expectMessage('number', typeof actual)}`);
             }
         },
         toBeBoolean: () => {
-            if(typeof actual === 'boolean'){
-                console.log('Test Passed');
-            }else {
+            if(typeof actual !== 'boolean'){
                 throw new CustomError(bgColor('Test Failed').error(), `${expectMessage('boolean', typeof actual)}`);
             }
         },
@@ -52,45 +42,33 @@ export const expect = (actual: any): ExpectationResult => {
             }
         },
         toBeObject: () => {
-            if(typeof actual === 'object'){
-                console.log('Test Passed');
-            }else {
+            if(typeof actual !== 'object'){
                 throw new CustomError(bgColor('Test Failed').error(), `${expectMessage('object', typeof actual)}`);
             }
         },
         not: {
             equalsTo: (expected: any) => {
-                if(!checkEqual(actual, expected)){
-                    console.log(bgColor('Test Passed').success());
-                }else {
+                if(checkEqual(actual, expected)){
                     throw new CustomError(bgColor('Test Failed').error(), `${expectMessage(`not ${expected.toString()}`, actual)}`);
                 }
             },
             toBeNull: () => {
-                if(actual != null){
-                    console.log('Test Passed');
-                }else {
+                if(actual === null){
                     throw new CustomError(bgColor('Test Failed').error(), `${expectMessage('not be null', typeof actual)}`);
                 }
             },
             toBeString: () => {
-                if(typeof actual != 'string'){
-                console.log('Test Passed');
-            }else {
-                throw new CustomError(bgColor('Test Failed').error(), `${expectMessage('not be string', typeof actual)}`);
-            }
+                if(typeof actual === 'string'){
+                    throw new CustomError(bgColor('Test Failed').error(), `${expectMessage('not be string', typeof actual)}`);
+                }
             },
             toBeNumber: () => {
-                if(typeof actual != 'number'){
-                    console.log('Test Passed');
-                }else {
+                if(typeof actual === 'number'){
                     throw new CustomError(bgColor('Test Failed').error(), `${expectMessage('not be number', typeof actual)}`);
                 }
             },
             toBeBoolean: () => {
-                if(typeof actual != 'boolean'){
-                    console.log('Test Passed');
-                }else {
+                if(typeof actual === 'boolean'){
                     throw new CustomError(bgColor('Test Failed').error(), `${expectMessage('not be boolean', typeof actual)}`);
                 }
             },
@@ -102,9 +80,7 @@ export const expect = (actual: any): ExpectationResult => {
                 }
             },
             toBeObject: () => {
-                if(typeof actual != 'object'){
-                    console.log('Test Passed');
-                }else {
+                if(typeof actual === 'object'){
                     throw new CustomError(bgColor('Test Failed').error(), `${expectMessage('not be object', typeof actual)}`);
                 }
             },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "forceConsistentCasingInFileNames": true,            
     "strict": true,                              
     "skipLibCheck": true,
-    "declaration": true
   },
   "include": ["types/**/*.d.ts", "src", "__tests__", "bin"],
   "exclude": ["node_modules", "build"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "forceConsistentCasingInFileNames": true,            
     "strict": true,                              
     "skipLibCheck": true,
+    "declaration": true
   },
   "include": ["types/**/*.d.ts", "src", "__tests__", "bin"],
   "exclude": ["node_modules", "build"],


### PR DESCRIPTION
This PR contains the code that makes the `suite` function available for consumers to use in order to group together the `test functions`

The PR must be able to do the following:-

1. Use the `suite function` to group together the `test functions`
2. After the execution of suite function the cli should provide a small summary of number of suites and test cases passed, failed and exeuted
3. In order to see the small summary we must also call the `result` function at the end of the `index.ts` file in `__test__` folder

example:
![image](https://user-images.githubusercontent.com/42911859/233620484-82c61ca8-d963-4e0e-baa5-53b9ba807a35.png)
